### PR TITLE
rinad: ipcm: parse_app_to_dif_mappings(): fix error handling

### DIFF
--- a/rinad/src/ipcm/configuration.cc
+++ b/rinad/src/ipcm/configuration.cc
@@ -879,8 +879,8 @@ bool parse_app_to_dif_mappings(const std::string& file_name,
 
         file.open(file_name.c_str());
         if (file.fail()) {
-                LOG_ERR("Failed to open apps to DIF mappings file");
-                return false;
+                LOG_WARN("Cannot open apps to DIF mappings file");
+                return true;
         }
 
         if (!reader.parse(file, root, false)) {

--- a/rinad/src/ipcm/dif-allocator.cc
+++ b/rinad/src/ipcm/dif-allocator.cc
@@ -34,7 +34,7 @@ using namespace std;
 
 namespace rinad {
 
-//Class DIF Template Manager
+//Class DIF Allocator
 const std::string DIFAllocator::DIF_DIRECTORY_FILE_NAME = "da.map";
 
 DIFAllocator::DIFAllocator(const std::string& folder)
@@ -53,7 +53,7 @@ DIFAllocator::DIFAllocator(const std::string& folder)
 
 	LOG_INFO("DIF Directory file: %s", fq_file_name.c_str());
 
-	//load current templates from template folder
+	//load current mappings
 	if (!parse_app_to_dif_mappings(fq_file_name, dif_directory)) {
 		LOG_ERR("Problems loading initial directory");
 	}
@@ -83,8 +83,11 @@ void DIFAllocator::update_directory_contents()
 {
 	rina::WriteScopedLock g(directory_lock);
 	dif_directory.clear();
-	parse_app_to_dif_mappings(fq_file_name, dif_directory);
-	LOG_DBG("DIF Allocator Directory updated!");
+	if (!parse_app_to_dif_mappings(fq_file_name, dif_directory)) {
+	    LOG_ERR("Problems while updating DIF Allocator Directory!");
+        } else {
+	    LOG_DBG("DIF Allocator Directory updated!");
+        }
 }
 
 } //namespace rinad

--- a/rinad/src/ipcm/dif-allocator.h
+++ b/rinad/src/ipcm/dif-allocator.h
@@ -51,4 +51,4 @@ private:
 
 } //namespace rinad
 
-#endif  /* __DIF_TEMPLATE_MONITOR_H__ */
+#endif  /* __DIF_ALLOCATOR_H__ */


### PR DESCRIPTION
If no da.map file is found, just print a warning, instead of an
error.
